### PR TITLE
4.7.0-preview.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ site-packages/nvidia-ml-py/t*
 /static/fonts/
 /static/js/
 /static/manifest.json
+manifest.json
 
 # ignore developments
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MoePhoto
-[![Badge](https://img.shields.io/badge/version-4.5.5-brightgreen.svg)](https://github.com/opteroncx/MoePhoto/blob/master/update_log.txt)
+[![Badge](https://img.shields.io/badge/version-4.7.0-brightgreen.svg)](https://github.com/opteroncx/MoePhoto/blob/master/update_log.txt)
 [![Badge](https://img.shields.io/badge/link-may--workshop-blueviolet.svg)](http://may-workshop.com/?page_id=373)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moephoto",
-  "version": "4.7.0-preview.3",
+  "version": "4.7.0-preview.4",
   "description": "MoePhoto Image Toolbox萌图工具箱   一个基于深度学习的AI图像修复软件（更新中...）   感兴趣的加QQ群320785467讨论   ### 基本功能 * 图像降噪 * 超分辨率 * 去雾 * 涂抹及风格化",
   "private": true,
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moephoto",
-  "version": "4.7.0-preview.4",
+  "version": "4.7.0-preview.5",
   "description": "MoePhoto Image Toolbox萌图工具箱   一个基于深度学习的AI图像修复软件（更新中...）   感兴趣的加QQ群320785467讨论   ### 基本功能 * 图像降噪 * 超分辨率 * 去雾 * 涂抹及风格化",
   "private": true,
   "directories": {

--- a/python/video.py
+++ b/python/video.py
@@ -72,7 +72,7 @@ def readSubprocess(q):
   while True:
     try:
       t, line = q.get_nowait()
-      line = str(line, encoding='utf_8')
+      line = str(line, encoding='utf_8', errors='replace')
     except Empty:
       break
     else:

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import json
 os.environ['TCL_LIBRARY'] = 'C:\\Users\\opteroncx.000\\Py36\\tcl\\tcl8.6'
 os.environ['TK_LIBRARY'] = 'C:\\Users\\opteroncx.000\\Py36\\tcl\\tk8.6'
 # Dependencies are automatically detected, but it might need fine tuning.
+manifestPath = './manifest.json'
 
 # include files
 ifiles = [
@@ -40,7 +41,8 @@ ifiles = [
         './libiompstubs5md.dll',
         './update_log.txt',
         './site-packages',
-        './server.bat'
+        './server.bat',
+        manifestPath
         ]
 
 # exclude files
@@ -71,6 +73,17 @@ exe = Executable(script='./python/MoePhoto.py', base = base, icon='logo3.ico')
 
 with open('package.json','r',encoding='utf-8') as manifest:
   version = json.load(manifest)['version']
+
+manifest = {
+  'version': version,
+  'releases': 'http://www.may-workshop.com/moephoto/version.html',
+  'ufile': 'http://www.may-workshop.com/moephoto/files/',
+  'ffmpeg-win': 'https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-latest-win64-static.zip',
+  'ffmpeg-linux': 'https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz'
+}
+
+with open(manifestPath, 'w') as f:
+  json.dump(manifest, f, ensure_ascii=False)
 
 setup(  name = 'MoePhoto',
         version = version,


### PR DESCRIPTION
想了想还是把用户侧当前版本放在`manifest.json`里面，[setup.py](setup.py)会自动生产这个然后包括在打包发布中

[defaultConfig.py](python/defaultConfig.py)里面的版本号仍然有用，表示API兼容的版本，preset功能使用到